### PR TITLE
Change snap base to `core22`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dotnet-manifest
-base: core24
+base: core22
 adopt-info: dotnet-manifest
 summary: The list of all available .NET content snap versions
 description: |
@@ -9,11 +9,11 @@ description: |
 grade: stable
 confinement: strict
 
-platforms:
-  amd64:
-    build-on: [amd64]
-  arm64:
-    build-on: [amd64]
+architectures:
+  - build-on: [amd64]
+    build-for: [amd64]
+  - build-on: [amd64]
+    build-for: [arm64]
 
 slots:
   dotnet-manifest:


### PR DESCRIPTION
The latest submission of the `dotnet` snap to the Snap Store failed with `confinement 'classic' not allowed with plugs/slots`. This was caused because the `dotnet-manifest` snap was listed as a default provider for the manifest plug, which was used solely as a mechanism to install this snap automatically along with the `dotnet` snap. However, slots/plugs are not allowed with classic snaps.

For this reason, this snap will be installed during the `install` hook of the `dotnet` snap. To minimize the download size, this PR changes the base of this snap to `core22` to match the base of the `dotnet` snap, thus making sure the base is already installed when the time comes to install this snap and avoiding the risk of running into a hook timeout.

See: https://github.com/canonical/dotnet-snap/pull/25